### PR TITLE
Fix radio button layout

### DIFF
--- a/tobaccocessation/templates/quizblock/single_choice.html
+++ b/tobaccocessation/templates/quizblock/single_choice.html
@@ -5,7 +5,8 @@
     {% if block.rhetorical %}
         <li><input name="question{{question.id}}" value="{{answer.label}}" type="radio" /> {{answer.label|safe}}</li>
     {% else %}
-        <li><div class="radio">        
+        <li><div class="radio">
+            <label>        
             {% if response %}
                 {% ifequal response.value answer.value %}
                     <input name="pageblock-{{block.pageblock.id}}-question{{question.id}}"
@@ -31,6 +32,7 @@
                        value="{{answer.value}}" type="radio" onclick="return showVideo(this);"/>
             {% endif %}
             {{answer.label|safe}}
+            </label>
         </div></li>
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
A <label> tag was needed to fix some wonky layout in FF and Chrome. (Safari was fine?). Problem was the ordered list labels (A,B,C) were overlapping the radio button.
http://getbootstrap.com/css/#default-stacked

<img width="320" alt="screen shot 2015-09-02 at 11 08 46 am" src="https://cloud.githubusercontent.com/assets/141369/9665716/f7e82a90-523f-11e5-929c-f32d106dbdc3.png">
