### PR TITLE
Missing Profile: redirect to create profile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -87,3 +87,5 @@ boto==2.36.0
 python-dateutil==2.4.2
 django-storages-redux==1.2.2
 django-cacheds3storage==0.1.1
+fake-factory==0.5.3
+factory_boy==2.6.0

--- a/tobaccocessation/main/tests/factories.py
+++ b/tobaccocessation/main/tests/factories.py
@@ -1,0 +1,19 @@
+import factory
+from pagetree.tests.factories import UserFactory
+
+from tobaccocessation.main.models import UserProfile
+
+
+class UserProfileFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = UserProfile
+
+    user = factory.SubFactory(UserFactory)
+    gender = 'M'
+    is_faculty = 'ST'
+    institute = 'I1'
+    specialty = 'S1'
+    hispanic_latino = 'Y'
+    year_of_graduation = 2015
+    consent_participant = True
+    consent_not_participant = False

--- a/tobaccocessation/main/tests/test_views.py
+++ b/tobaccocessation/main/tests/test_views.py
@@ -1,37 +1,21 @@
-from django.contrib.auth.models import User
-from django.test import TestCase, RequestFactory
-from django.test.client import Client
-from pagetree.models import Hierarchy, Section
-from tobaccocessation.main.models import UserProfile
+from django.test import TestCase
+from pagetree.models import Hierarchy
+from pagetree.tests.factories import ModuleFactory, UserFactory
+
+from tobaccocessation.main.tests.factories import UserProfileFactory
 
 
 class TestViews(TestCase):
     def setUp(self):
-        self.c = Client()
-        self.factory = RequestFactory()
-        self.user = User.objects.create_user('test_student',
-                                             'test@ccnmtl.com',
-                                             'testpassword')
-        self.user.save()
+        self.user = UserFactory()
 
-        self.hierarchy = Hierarchy(name="main", base_url="/")
-        self.hierarchy.save()
-
-        root = Section.add_root(label="Root", slug="",
-                                hierarchy=self.hierarchy)
-
-        root.append_child("Section 1", "section-1")
-        root.append_child("Section 2", "section-2")
-
-        self.section1 = Section.objects.get(slug="section-1")
-        self.section2 = Section.objects.get(slug="section-2")
-
-    def tearDown(self):
-        self.user.delete()
+        ModuleFactory("main", "/pages/main/")
+        hierarchy = Hierarchy.objects.get(name='main')
+        self.section = hierarchy.get_root().get_first_leaf()
 
     def test_index(self):
         # it should redirect us somewhere.
-        response = self.c.get("/")
+        response = self.client.get("/")
         self.assertEquals(response.status_code, 302)
         # for now, we don't care where. really, we
         # are just making sure it's not a 500 error
@@ -41,72 +25,56 @@ class TestViews(TestCase):
         # run the smoketests. we don't care if they pass
         # or fail, we just want to make sure that the
         # smoketests themselves don't have an error
-        response = self.c.get("/smoketest/")
+        response = self.client.get("/smoketest/")
         self.assertEquals(response.status_code, 200)
 
-    def test_accessible(self):
-        pass
-        # Need better test...
-
-    def test_is_accessible(self):
-        pass
-
-    def test_clear_state(self):
-        pass
-
     def test_consent_no_profile(self):
-        self.c = Client()
-        self.c.login(username='test_student', password='testpassword')
-        self.response = self.c.get('/', follow=True)
-        self.assertEqual(self.response.status_code, 200)
-        self.assertEquals(self.response.redirect_chain[0][1], 302)
-        self.assertEquals(self.response.templates[0].name,
+        self.client.login(username=self.user.username, password='test')
+        response = self.client.get('/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEquals(response.redirect_chain[0][1], 302)
+        self.assertEquals(response.templates[0].name,
                           "main/create_profile.html")
 
     def test_consent_incomplete_profile(self):
         # User has a profile, but does not have "consent" or other
         # special fields filled out. Redirect to create profile
-        UserProfile.objects.create(user=self.user,
-                                   gender='M',
-                                   is_faculty='ST',
-                                   institute='I1',
-                                   specialty='S1',
-                                   hispanic_latino='Y',
-                                   year_of_graduation=2015,
-                                   consent_participant=False,
-                                   consent_not_participant=False)
+        UserProfileFactory(user=self.user,
+                           consent_participant=False,
+                           consent_not_participant=False)
 
-        self.c = Client()
-        self.c.login(username='test_student', password='testpassword')
-        self.response = self.c.get('/', follow=True)
-        self.assertEqual(self.response.status_code, 200)
-        self.assertEquals(self.response.templates[0].name,
+        self.client.login(username=self.user.username, password='test')
+        response = self.client.get('/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEquals(response.templates[0].name,
                           "main/create_profile.html")
-        self.assertEquals(self.response.redirect_chain[0][1], 302)
+        self.assertEquals(response.redirect_chain[0][1], 302)
 
     def test_consent_complete_profile(self):
         # User has a complete profile
-        profile = UserProfile.objects.create(user=self.user,
-                                             gender='M',
-                                             is_faculty='ST',
-                                             institute='I1',
-                                             specialty='S1',
-                                             hispanic_latino='Y',
-                                             year_of_graduation=2015,
-                                             consent_participant=True,
-                                             consent_not_participant=False)
-        profile.gender = 'F'
-        profile.is_faculty = 'ST'
-        profile.specialty = 'S10'
-        profile.year_of_graduation = 2014
-        profile.consent_participant = True
-        profile.consent_not_participant = False
-        profile.save()
+        UserProfileFactory(user=self.user)
 
-        self.c = Client()
-        self.c.login(username='test_student', password='testpassword')
-        self.response = self.c.get('/', follow=True)
-        self.assertEqual(self.response.status_code, 200)
-        self.assertEquals(self.response.templates[0].name,
+        self.client.login(username=self.user.username, password='test')
+        response = self.client.get('/', follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEquals(response.templates[0].name,
                           "main/index.html")
-        self.assertEquals(len(self.response.redirect_chain), 0)
+        self.assertEquals(len(response.redirect_chain), 0)
+
+    def test_page_no_profile(self):
+        self.client.login(username=self.user.username, password='test')
+        response = self.client.get(self.section.get_absolute_url(),
+                                   follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertEquals(response.redirect_chain[0][1], 302)
+        self.assertEquals(response.templates[0].name,
+                          "main/create_profile.html")
+
+    def test_page_profile(self):
+        UserProfileFactory(user=self.user)
+
+        self.client.login(username=self.user.username, password='test')
+        response = self.client.get(self.section.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertEquals(response.templates[0].name,
+                          "main/page.html")

--- a/tobaccocessation/main/views.py
+++ b/tobaccocessation/main/views.py
@@ -104,6 +104,10 @@ def page_post(request, section):
 @login_required
 @rendered_with('main/page.html')
 def page(request, hierarchy, path):
+    profile = UserProfile.objects.filter(user=request.user).first()
+    if profile is None:
+        return HttpResponseRedirect(reverse('create_profile'))
+
     section = get_section_from_path(path, hierarchy)
     h = section.hierarchy
     if request.method == "POST":
@@ -111,7 +115,6 @@ def page(request, hierarchy, path):
         return page_post(request, section)
     first_leaf = h.get_first_leaf(section)
     ancestors = first_leaf.get_ancestors()
-    profile = UserProfile.objects.filter(user=request.user)[0]
 
     # Skip to the first leaf, make sure to mark these sections as visited
     if (section != first_leaf):


### PR DESCRIPTION
Sentry error indicates a user somehow made it to pagetree content without a profile.
Guard this situation by checking for a user profile before displaying content. Redirect
to create profile when necessary. (It's unclear how the user made it through)

Also, a little cleanup work in tests, adding factories & new tests.