### PR TITLE
add django-bootstrap3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,7 @@ django-compressor==2.0
 django-statsd-mozilla==0.3.16
 raven==5.20.0
 django-bootstrap-form==3.2.1
+django-bootstrap3==7.0.1
 django-debug-toolbar==1.4
 django-waffle==0.11.1
 django-jenkins==0.18.1


### PR DESCRIPTION
required by some pagetree templates