### PR TITLE
Switch to modern rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,18 @@
         }
       }
     },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
+      }
+    },
     "ajv-keywords": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
@@ -539,27 +551,27 @@
       }
     },
     "eslint": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.13.1.tgz",
-      "integrity": "sha512-UCJVV50RtLHYzBp1DZ8CMPtRSg4iVZvjgO9IJHIKyWU/AnJVjtdRikoUPLB29n5pzMB7TnsLQWf0V6VUJfoPfw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
+      "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
       "dev": true,
       "requires": {
-        "ajv": "5.5.1",
+        "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
-        "doctrine": "2.0.2",
+        "doctrine": "2.1.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.2",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
         "esquery": "1.0.0",
-        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "2.0.0",
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
-        "globals": "11.1.0",
+        "globals": "11.3.0",
         "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "3.2.3",
@@ -584,22 +596,10 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
           "dev": true
-        },
-        "ajv": {
-          "version": "5.5.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
-          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
         },
         "debug": {
           "version": "3.1.0",
@@ -611,28 +611,28 @@
           }
         },
         "doctrine": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-          "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
           "dev": true,
           "requires": {
             "esutils": "2.0.2"
           }
         },
         "espree": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-          "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+          "version": "3.5.4",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
           "dev": true,
           "requires": {
-            "acorn": "5.2.1",
+            "acorn": "5.5.3",
             "acorn-jsx": "3.0.1"
           }
         },
         "globals": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.1.0.tgz",
-          "integrity": "sha512-uEuWt9mqTlPDwSqi+sHjD4nWU/1N+q0fiWI9T1mZpD2UENqX20CFD5T/ziLZvztPaBKl7ZylUi1q6Qfm7E2CiQ==",
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
           "dev": true
         }
       }
@@ -643,7 +643,7 @@
       "integrity": "sha1-YsqLQH6gksO01DATuttuep4tqsM=",
       "dev": true,
       "requires": {
-        "eslint": "4.13.1",
+        "eslint": "4.17.0",
         "eslint-plugin-no-unsanitized": "2.0.1",
         "eslint-plugin-no-wildcard-postmessage": "0.1.3",
         "eslint-plugin-scanjs-rules": "0.2.1"
@@ -1448,7 +1448,7 @@
       "dev": true,
       "requires": {
         "babel-eslint": "7.2.3",
-        "eslint": "4.13.1"
+        "eslint": "4.17.0"
       }
     },
     "eslint-plugin-security": {
@@ -1469,6 +1469,12 @@
         "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
       }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
     },
     "espree": {
       "version": "3.5.0",


### PR DESCRIPTION
Removing the hand-rolled `rendered_with` method in favor of Django's `render`. The request context was not trickling down into the view, leaving these pages without essentials like `STATIC_URL`.